### PR TITLE
Issue#52/fix snid problem

### DIFF
--- a/examples/reference_lc.ipynb
+++ b/examples/reference_lc.ipynb
@@ -85,8 +85,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/manual/anaconda/lib/python2.7/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
-      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
+      "/usr/local/miniconda/lib/python2.7/site-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.\n",
+      "  \"`IPython.html.widgets` has moved to `ipywidgets`.\", ShimWarning)\n"
      ]
     }
    ],
@@ -108,11 +108,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/rbiswas/src/LSST/sims_catalogs_generation/python/lsst/sims/catalogs/generation/db/dbConnection.py:438: UserWarning: Duplicate object type id 25 specified: \n",
+      "/Users/rbiswas/src/LSST_el_Capitan/sims_catalogs/python/lsst/sims/catalogs/db/dbConnection.py:439: UserWarning: Duplicate object type id 25 specified: \n",
       "Output object ids may not be unique.\n",
       "This may not be a problem if you do not want globally unique id values\n",
       "  'want globally unique id values')\n",
-      "/Users/rbiswas/src/LSST/sims_catalogs_generation/python/lsst/sims/catalogs/generation/db/dbConnection.py:438: UserWarning: Duplicate object type id 40 specified: \n",
+      "/Users/rbiswas/src/LSST_el_Capitan/sims_catalogs/python/lsst/sims/catalogs/db/dbConnection.py:439: UserWarning: Duplicate object type id 40 specified: \n",
       "Output object ids may not be unique.\n",
       "This may not be a problem if you do not want globally unique id values\n",
       "  'want globally unique id values')\n"
@@ -252,7 +252,7 @@
     {
      "data": {
       "text/plain": [
-       "<pymssql.Connection at 0x124902290>"
+       "<pymssql.Connection at 0x12118ee18>"
       ]
      },
      "execution_count": 11,
@@ -406,7 +406,7 @@
        "      <th>c</th>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>snid</th>\n",
+       "      <th>id</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -433,11 +433,11 @@
       ],
       "text/plain": [
        "               redshift       snra      sndec          t0      x0        x1  \\\n",
-       "snid                                                                          \n",
+       "id                                                                            \n",
        "6000006889903    0.0792  53.005626 -27.389538  3627.69276  0.0008 -0.286958   \n",
        "\n",
        "                      c  \n",
-       "snid                     \n",
+       "id                       \n",
        "6000006889903 -0.086294  "
       ]
      },
@@ -474,7 +474,7 @@
        "      <th>c</th>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>snid</th>\n",
+       "      <th>id</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -511,12 +511,12 @@
       ],
       "text/plain": [
        "               redshift       snra      sndec           t0        x0  \\\n",
-       "snid                                                                   \n",
+       "id                                                                     \n",
        "6000006889903    0.0792  53.005626 -27.389538  3627.692760  0.000800   \n",
        "6000154757305    0.0882  53.051542 -27.414282  3565.558086  0.001018   \n",
        "\n",
        "                     x1         c  \n",
-       "snid                               \n",
+       "id                                 \n",
        "6000006889903 -0.286958 -0.086294  \n",
        "6000154757305  0.607759 -0.261934  "
       ]
@@ -580,7 +580,7 @@
        "      <th>c</th>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>snid</th>\n",
+       "      <th>id</th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
@@ -647,7 +647,7 @@
       ],
       "text/plain": [
        "               redshift       snra      sndec           t0        x0  \\\n",
-       "snid                                                                   \n",
+       "id                                                                     \n",
        "6001163623700    0.3401  52.803079 -27.843361  1731.094090  0.000025   \n",
        "6000324908000    0.3249  52.797229 -27.843795  1664.942389  0.000037   \n",
        "6000324908001    0.3249  52.797248 -27.843597  1608.347547  0.000025   \n",
@@ -655,7 +655,7 @@
        "6000350930401    0.6747  52.798069 -27.846654  2128.934351  0.000005   \n",
        "\n",
        "                     x1         c  \n",
-       "snid                               \n",
+       "id                                 \n",
        "6001163623700 -1.981708 -0.043500  \n",
        "6000324908000  0.697824 -0.140121  \n",
        "6000324908001 -0.238670  0.053811  \n",
@@ -1197,10 +1197,10 @@
    "outputs": [],
    "source": [
     "reflcTwink = RefLightCurves.fromTwinklesData(tableName='TwinkSN',\n",
-    "                                             idCol='snid',\n",
+    "                                             idCol='id',\n",
     "                                             objectTypeID=42,\n",
     "                                             dbHostName=None,\n",
-    "                                             columns=('snid', 'redshift', 'snra', 'sndec', 't0',\n",
+    "                                             columns=('id', 'redshift', 'snra', 'sndec', 't0',\n",
     "                                                      'x0', 'x1', 'c'),\n",
     "                                             idSequence=None)"
    ]
@@ -1226,6 +1226,28 @@
   {
    "cell_type": "code",
    "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'id'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reflcTwink.idCol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -1659,7 +1681,7 @@
        "2442775      z  1.157850e-08  1.512941e-10  22.905166  63222.085677"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1679,7 +1701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -1780,7 +1802,7 @@
        "2442742      r  2.680369e-08  8.657722e-11  23.998963  63222.067830"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1788,11 +1810,21 @@
    "source": [
     "reflcTwink.lightCurve(idValue=6144007055260714, bandName='r')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -1806,7 +1838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/python/desc/monitor/dbConnection.py
+++ b/python/desc/monitor/dbConnection.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import numpy as np
-from lsst.sims.catalogs.generation.db import DBObject
+from lsst.sims.catalogs.db import DBObject
 
 __all__ = ['dbInterface']
 

--- a/python/desc/monitor/truth.py
+++ b/python/desc/monitor/truth.py
@@ -27,7 +27,7 @@ class RefLightCurves(object):
     tableName : string, mandatory
         case insensitive string name of table on database to connect to
         for model parameters of astrophysical objects
-    idCol : string, optional, defaults to 'snid'
+    idCol : string, optional, defaults to 'id'
         column name of Index on the table
     observations : `pd.DataFrame`, optional, defaults to None
         if None, some information may need to be supplied in using certain
@@ -84,8 +84,8 @@ class RefLightCurves(object):
     def __init__(self,
                  tableName,
                  objectTypeID=42,
-                 idCol='snid',
-                 columns=('snid', 'redshift', 'snra', 'sndec', 't0', 'x0',
+                 idCol='id',
+                 columns=('id', 'redshift', 'snra', 'sndec', 't0', 'x0',
                           'x1', 'c'),
                  observations=None,
                  bandPassDict=None,
@@ -112,8 +112,8 @@ class RefLightCurves(object):
                          tableName,
                          objectTypeID=42,
                          dbHostName=None,
-                         idCol='snid',
-                         columns=('snid', 'redshift', 'snra', 'sndec', 't0',
+                         idCol='id',
+                         columns=('id', 'redshift', 'snra', 'sndec', 't0',
                                   'x0', 'x1', 'c'),
                          idSequence=None):
         """
@@ -125,7 +125,7 @@ class RefLightCurves(object):
         tableName : string, mandatory
             case insensitive string name of table on database to connect to
             for model parameters of astrophysical objects
-        idCol : string, optional, defaults to 'snid'
+        idCol : string, optional, defaults to 'id'
             column name of Index on the table
         columns : tuple of strings, optional, defaults to values for SN
             tuple of strings that completely specify the truth values for


### PR DESCRIPTION
- Changed import of `DBObject` in dbConnection to reflect changes to catsim architecture
- Changed `snid` to `id` in `truth.py` to reflect changes to catsim database table variable names
- Changed `snid` to `id` and fixed `DBObject` import  in example notebook.

Notebook works on my computer.

Fixes #52 
